### PR TITLE
fix: Remove skcm repo link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@boxfish-studio/sveltekit-cookie-manager",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@boxfish-studio/sveltekit-cookie-manager",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "1.0.0-next.84",
 				"@sveltejs/kit": "1.0.0-next.522",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@boxfish-studio/sveltekit-cookie-manager",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/lib/app/constants.ts
+++ b/src/lib/app/constants.ts
@@ -9,10 +9,7 @@ export const GOOGLE_COOKIE_PROVIDER: CookieProvider = {
 	url: 'https://policies.google.com/privacy'
 }
 
-export const SKCM_COOKIE_PROVIDER: CookieProvider = {
-	name: 'SKCM',
-	url: 'https://github.com/boxfish-studio/sveltekit-cookie-mananger'
-}
+export const SKCM_COOKIE_PROVIDER_NAME = "SKCM";
 
 export const DEFAULT_DISCLAIMER_CONFIG: DisclaimerConfiguration = {
 	title: 'Cookie Preferences',

--- a/src/lib/app/cookieLib.ts
+++ b/src/lib/app/cookieLib.ts
@@ -3,15 +3,14 @@ import {
 	COOKIE_NAME_PREFIX,
 	GOOGLE_ANALYTICS_EXPIRATION_DAYS,
 	GOOGLE_COOKIE_PROVIDER,
-	SKCM_COOKIE_PROVIDER
+	SKCM_COOKIE_PROVIDER_NAME
 } from './constants'
 import { CookieCategory, CookieType } from './enums'
 import type { ServiceCookie } from './types'
 
 export const SKCM_GA_GOOGLE_ANALYTICS_UNIVERSAL_COOKIE: ServiceCookie = {
 	name: `${COOKIE_NAME_PREFIX}-ga-universal`,
-	provider: SKCM_COOKIE_PROVIDER.name,
-	providerUrl: SKCM_COOKIE_PROVIDER.url,
+	provider: SKCM_COOKIE_PROVIDER_NAME,
 	purpose:
 		'Stores the user´s Google Analytics Universal cookies consent state for the current domain',
 	expiry: COOKIE_EXPIRATION_DAYS + ' days',
@@ -21,8 +20,7 @@ export const SKCM_GA_GOOGLE_ANALYTICS_UNIVERSAL_COOKIE: ServiceCookie = {
 
 export const SKCM_GA_GOOGLE_ANALYTICS_4_COOKIE: ServiceCookie = {
 	name: `${COOKIE_NAME_PREFIX}-ga-4`,
-	provider: SKCM_COOKIE_PROVIDER.name,
-	providerUrl: SKCM_COOKIE_PROVIDER.url,
+	provider: SKCM_COOKIE_PROVIDER_NAME,
 	purpose: 'Stores the user´s Google Analytics 4 cookies consent state for the current domain',
 	expiry: COOKIE_EXPIRATION_DAYS + ' days',
 	type: CookieType.HTTP,

--- a/src/lib/components/CookieLibrary/NecessaryCookies.svelte
+++ b/src/lib/components/CookieLibrary/NecessaryCookies.svelte
@@ -7,7 +7,6 @@
 		<thead>
 			<tr>
 				<th> Name </th>
-				<th> Provider </th>
 				<th> Purpose </th>
 				<th> Expiry </th>
 				<th> Type </th>
@@ -17,11 +16,6 @@
 			{#each $necessaryCookies as cookie}
 				<tr>
 					<td> {cookie?.name}</td>
-					<td
-						><a href={cookie?.providerUrl} target="_blank" rel="noopener noreferrer nofollow">
-							{cookie?.provider}</a
-						>
-					</td>
 					<td> {cookie?.purpose} </td>
 					<td> {cookie?.expiry} </td>
 					<td> {cookie?.type} </td>


### PR DESCRIPTION
# Changes
- Removes the SKCM link from the SKCM provider.
- Bumps the version to `1.0.1`